### PR TITLE
Unique based on station name and cruise name

### DIFF
--- a/sql/unique_stations.sql
+++ b/sql/unique_stations.sql
@@ -1,2 +1,2 @@
 --ACCESS=access content
-select stationname, round(avg(decimallatitude)::numeric,4) as avglat, round(avg(decimallongitude)::numeric,4) as avglong , round(avg(bottomdepthinmeters)::numeric,1) as avgdepth, stationname as sname from aen group by stationname order by stationname;
+select uniqueStation, round(avg(decimallatitude)::numeric,4) as avglat, round(avg(decimallongitude)::numeric,4) as avglong , round(avg(bottomdepthinmeters)::numeric,1) as avgdepth, uniqueStation as sname from aen group by uniqueStation order by uniqueStation;


### PR DESCRIPTION
The station names have sometimes been mismanaged through the project, and so the same station name has been used on different cruises to represent different locations. Therefore, I have added a 'uniqueStations' column that in most cases is a concatenation of station name and cruise name. 

Exceptions are stations listed in 'stations.csv' where the coordinates are predefined (NLEG stations) or definitely unique (NPAL stations). In this case we uniqueStation = stationName. 

uniqueStation will be used when plotting the stations on the map on the SIOS website, Nansen Legacy tools. The unique_stations.sql script in the Aen_sample repo has been updated, which is used to create a CSV that is used for plotting these station and their coordinates. 